### PR TITLE
Clean up Makefile and README

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,7 @@ APPS = kernel stdlib sasl erts ssl tools runtime_tools crypto inets \
 	public_key mnesia syntax_tools compiler
 COMBO_PLT = $(HOME)/.dobby_combo_dialyzer_plt
 
-.PHONY: all compile deps test clean distclean ct
-
-all: compile
+.PHONY: compile deps test clean ct build_plt check_plt
 
 compile:
 	./rebar get-deps compile
@@ -17,9 +15,6 @@ eunit: compile
 
 ct: compile
 	./rebar -v ct $(CTARGS)
-
-distclean: clean
-	./rebar delete-deps
 
 clean:
 	./rebar clean
@@ -41,7 +36,9 @@ dialyzer: compile
 
 dev: compile
 	erl -pa ebin -pa deps/*/ebin \
-	-eval "application:ensure_all_started(dobby_oflib)."
+	-eval "application:ensure_all_started(dobby)." \
+	-name dobby@127.0.0.1 \
+	-setcookie dobby
 
 compile test clean: rebar
 

--- a/README.md
+++ b/README.md
@@ -11,8 +11,37 @@ standalone service.
 
 This is an open source project sponsored by Infoblox.
 
+<!-- markdown-toc start - Don't edit this section. Run M-x markdown-toc/generate-toc again -->
+**Table of Contents**
+
+- [Dobby](#dobby)
+    - [Requirements](#requirements)
+    - [Building](#building)
+    - [Running](#running)
+    - [Clients](#clients)
+    - [Utility Functions](#utility-functions)
+        - [json import/export format](#json-importexport-format)
+    - [Origin of Name](#origin-of-name)
+
+<!-- markdown-toc end -->
+
+
 ## Requirements
 - Erlang R17+
+
+## Building
+To build the application call: `make`.
+
+## Running
+
+To run `dobby` as an Erlang node use
+[dobby_allinone_node](https://github.com/ivanos/dobby_allinone_node).
+
+To run `dobby` straight away call `make dev`.
+
+## Clients
+Use [dobby_clib](https://github.com/ivanos/dobby_clib) to send commands
+to the dobby server.
 
 ## Utility Functions
 - dby_bulk:export(Format, Filename): writes the graph database to the


### PR DESCRIPTION
Now dobby is a library and some Makefile targets are unusable.
