### PR TITLE
Update dependencies, Makefile, README

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,10 +4,7 @@ COMBO_PLT = $(HOME)/.dobby_combo_dialyzer_plt
 
 .PHONY: all compile deps test clean distclean ct
 
-all: generate
-
-generate: compile
-	./rebar generate
+all: compile
 
 compile:
 	./rebar get-deps compile

--- a/README.md
+++ b/README.md
@@ -4,47 +4,15 @@ server.  Unlike the IF-Map server, Dobby is intended to be a more
 general purpose graph database that applications can then use for
 whatever purpose they require.
 
+This repository, dobby_core_lib is the implementation of dobby which
+can be used as a dependency to build nodes containing a dobby server.
+https://github.com/ivanos/dobby_core_node.git runs Dobby as a
+standalone service.
+
 This is an open source project sponsored by Infoblox.
 
 ## Requirements
 - Erlang R17+
-
-## Building
-If you want to connect to the dobby Erlang shell using ssh with
-keys, you must
-generate keys for `deps/erl_sshd`.  Using make:
-```
-% make
-```
-Using rebar directly:
-```
-% rebar get-deps
-% rebar compile
-% deps/erl_sshd/make_keys
-% rebar generate
-```
-You may add your own public keys to the `authorized_keys` file in
-`priv/erl_sshd` (remember to `rebar generate` afterwards).
-
-If you want to connect to the dobby Erlang shell using ssh with
-a username and password,
-add or modify the usernames and passwords
-to the `erl_sshd` section of `rel/files/sys.config`.
-
-## Running
-```
-% rel/dobby/bin/dobby console
-```
-
-## Connecting via ssh
-If you genereated keys in erl_sshd before generating the dobby release,
-you can connect to the dobby server's Erlang shell using ssh.
-```
-ssh 127.0.0.1 -p 11133 -i id_rsa
-```
-
-## Clients
-Use `dobby_clib` to send commands to the dobby server.
 
 ## Utility Functions
 - dby_bulk:export(Format, Filename): writes the graph database to the

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ server.  Unlike the IF-Map server, Dobby is intended to be a more
 general purpose graph database that applications can then use for
 whatever purpose they require.
 
-This repository, dobby_core_lib is the implementation of dobby which
+This repository, dobby_core_lib, is the implementation of Dobby which
 can be used as a dependency to build nodes containing a dobby server.
 https://github.com/ivanos/dobby_core_node.git runs Dobby as a
 standalone service.

--- a/rebar.config
+++ b/rebar.config
@@ -6,7 +6,7 @@
 
 {deps_dir, "deps"}.
 {deps, [
-        {dobby_clib, ".*", {git, "https://github.com/shivarammysore/dobby_clib.git", {branch,"master"}}},
+        {dobby_clib, ".*", {git, "https://github.com/ivanos/dobby_clib.git", {branch,"master"}}},
         {'iso8601', ".*", {git, "https://github.com/seansawyer/erlang_iso8601.git", {tag, "1.1.1"}}},
         {lager, ".*", {git, "https://github.com/basho/lager.git", {tag,"2.1.1"}}},
         {jiffy, ".*", {git, "https://github.com/davisp/jiffy.git", {tag, "0.13.3"}}},


### PR DESCRIPTION
Update dependencies to use ivanos.

Makefile and README changed to reflect that this repo is no longer a node.
